### PR TITLE
Adding black code formatter to CI

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -1,0 +1,18 @@
+name: black
+
+on: [push, pull_request]
+
+# use workaround due to: https://github.com/psf/black/issues/2079#issuecomment-812359146
+jobs:
+    check-formatting:
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up Python 3.11
+              uses: actions/setup-python@v2
+              with:
+                python-version: '3.11'
+            - name: Install Black
+              run: pip install 'black==22.6.0'
+            - name: Run black --check .
+              run: black --check .

--- a/armicontrib/armiopenmc/executers.py
+++ b/armicontrib/armiopenmc/executers.py
@@ -97,9 +97,11 @@ class OpenMCExecuter(globalFluxInterface.GlobalFluxExecuter):
                 f"Cannot find executable at {self.options.executablePath}. " f"Update run settings."
             )
 
-        openmc.run(threads=self.options.nOMPThreads,
-                   mpi_args=['mpiexec','-n',str(self.options.nMPIProcesses), '--bind-to', 'none'],
-                   openmc_exec=self.options.executablePath)
+        openmc.run(
+            threads=self.options.nOMPThreads,
+            mpi_args=["mpiexec", "-n", str(self.options.nMPIProcesses), "--bind-to", "none"],
+            openmc_exec=self.options.executablePath,
+        )
 
         return True
 
@@ -107,5 +109,5 @@ class OpenMCExecuter(globalFluxInterface.GlobalFluxExecuter):
     def _readOutput(self):
         """Read output."""
         reader = outputReaders.OpenMCReader(self.options)
-        #reader.apply(self.r)
+        # reader.apply(self.r)
         return reader

--- a/armicontrib/armiopenmc/executionOptions.py
+++ b/armicontrib/armiopenmc/executionOptions.py
@@ -83,20 +83,18 @@ class OpenMCOptions(globalFluxInterface.GlobalFluxOptions):
     def fromReactor(self, reactor):
         """Set options from an ARMI composite to be modeled (often a ``Core``)"""
         globalFluxInterface.GlobalFluxOptions.fromReactor(self, reactor)
-        self.inputFile = None #f"{self.label}.inp"
-        self.outputFile = None #f"{self.label}.out"
+        self.inputFile = None  # f"{self.label}.inp"
+        self.outputFile = None  # f"{self.label}.out"
 
     def resolveDerivedOptions(self):
         """
         Set other options that are dependent on previous phases of loading options.
         """
         globalFluxInterface.GlobalFluxOptions.resolveDerivedOptions(self)
-        self.extraInputFiles.extend(["geometry.xml",
-                                     "materials.xml",
-                                     "settings.xml",
-                                     "tallies.xml",
-                                     "plots.xml"])
-        self.outputFile = "statepoint."+str(self.nBatches)+".h5"
+        self.extraInputFiles.extend(
+            ["geometry.xml", "materials.xml", "settings.xml", "tallies.xml", "plots.xml"]
+        )
+        self.outputFile = "statepoint." + str(self.nBatches) + ".h5"
         if self.existingFixedSource:
             self.extraInputFiles.append((self.existingFixedSource, self.existingFixedSource))
         if self.isRestart:

--- a/armicontrib/armiopenmc/inputWriters.py
+++ b/armicontrib/armiopenmc/inputWriters.py
@@ -36,6 +36,7 @@ from armi.physics.neutronics import energyGroups
 
 import openmc
 
+
 class OpenMCWriter:
     """
     Write OpenMC data using the openmc python api.
@@ -58,37 +59,59 @@ class OpenMCWriter:
     def writeGeometry(self):
         """Write the openmc geometry, materials, and plots input file."""
 
-        def blendHelixComponentsIntoCoolant(block, solventName='coolant'):
+        def blendHelixComponentsIntoCoolant(block, solventName="coolant"):
             """OpenMC doesn't support helixes, so blend them all into coolant"""
             helixComponentNames = []
             for component in block:
                 if isinstance(component, complexShapes.Helix):
-                    helixComponentNames.append(component.getName()) 
-            if len(helixComponentNames)>0:
-                block = MultipleComponentMerger(sourceBlock=block, soluteNames=helixComponentNames, solventName=solventName).convert()
+                    helixComponentNames.append(component.getName())
+            if len(helixComponentNames) > 0:
+                block = MultipleComponentMerger(
+                    sourceBlock=block, soluteNames=helixComponentNames, solventName=solventName
+                ).convert()
             return block
 
-        def buildCellRegion(component, bottomPlane, topPlane, origin=(0.0,0.0), outsideBuffer=0.0):
+        def buildCellRegion(component, bottomPlane, topPlane, origin=(0.0, 0.0), outsideBuffer=0.0):
             """Build region based on shape"""
 
             # Circle
             if isinstance(component, basicShapes.Circle):
-                innerCylinder = openmc.ZCylinder(x0=origin[0], y0=origin[1], r=component.getDimension("id")/2)
-                outerCylinder = openmc.ZCylinder(x0=origin[0], y0=origin[1], r=component.getDimension("od")/2 + outsideBuffer)
+                innerCylinder = openmc.ZCylinder(
+                    x0=origin[0], y0=origin[1], r=component.getDimension("id") / 2
+                )
+                outerCylinder = openmc.ZCylinder(
+                    x0=origin[0], y0=origin[1], r=component.getDimension("od") / 2 + outsideBuffer
+                )
                 region = +bottomPlane & -topPlane & +innerCylinder & -outerCylinder
                 return region
 
             # Hexagon
             if isinstance(component, basicShapes.Hexagon):
-                innerHexPrism = openmc.model.hexagonal_prism(edge_length=component.getDimension("ip")/3**.5, orientation='x', origin=origin)
-                outerHexPrism = openmc.model.hexagonal_prism(edge_length=component.getDimension("op")/3**.5 + outsideBuffer, orientation='x', origin=origin)
+                innerHexPrism = openmc.model.hexagonal_prism(
+                    edge_length=component.getDimension("ip") / 3**0.5,
+                    orientation="x",
+                    origin=origin,
+                )
+                outerHexPrism = openmc.model.hexagonal_prism(
+                    edge_length=component.getDimension("op") / 3**0.5 + outsideBuffer,
+                    orientation="x",
+                    origin=origin,
+                )
                 region = +bottomPlane & -topPlane & ~innerHexPrism & outerHexPrism
                 return region
 
             # Rectangle
             if isinstance(component, basicShapes.Rectangle):
-                innerRectPrism = openmc.model.rectangular_prism(width=component.getDimension("widthInner"), height=component.getDimension("lengthInner"), origin=origin) # Check that width/height aren't flipped
-                outerRectPrism = openmc.model.rectangular_prism(width=component.getDimension("widthOuter")+outsideBuffer, height=component.getDimension("lengthOuter")+outsideBuffer, origin=origin)
+                innerRectPrism = openmc.model.rectangular_prism(
+                    width=component.getDimension("widthInner"),
+                    height=component.getDimension("lengthInner"),
+                    origin=origin,
+                )  # Check that width/height aren't flipped
+                outerRectPrism = openmc.model.rectangular_prism(
+                    width=component.getDimension("widthOuter") + outsideBuffer,
+                    height=component.getDimension("lengthOuter") + outsideBuffer,
+                    origin=origin,
+                )
                 region = +bottomPlane & -topPlane & ~innerRectPrism & outerRectPrism
                 return region
 
@@ -108,30 +131,56 @@ class OpenMCWriter:
             # Others
             raise NotImplementedError("Shape type not supported yet")
 
-        def buildCell(component, material, block, bottomPlane, topPlane, origin=(0.0,0.0), outsideBuffer=0.0):
-            if component.getDimension("mult")==1:
-                        cell = openmc.Cell(name=component.getName(),
-                                           fill=material,
-                                           region=buildCellRegion(component, bottomPlane=blockBottomPlane, topPlane=blockTopPlane, origin=origin, outsideBuffer=outsideBuffer))
+        def buildCell(
+            component, material, block, bottomPlane, topPlane, origin=(0.0, 0.0), outsideBuffer=0.0
+        ):
+            if component.getDimension("mult") == 1:
+                cell = openmc.Cell(
+                    name=component.getName(),
+                    fill=material,
+                    region=buildCellRegion(
+                        component,
+                        bottomPlane=blockBottomPlane,
+                        topPlane=blockTopPlane,
+                        origin=origin,
+                        outsideBuffer=outsideBuffer,
+                    ),
+                )
             else:
                 if block.hasPinPitch():
                     latticePitch = block.getPinPitch()
                 else:
-                    latticePitch = 1.2*max([component.getBoundingCircleOuterDiameter() for component in block.getComponents() if component.getDimension("mult")!=1])
+                    latticePitch = 1.2 * max(
+                        [
+                            component.getBoundingCircleOuterDiameter()
+                            for component in block.getComponents()
+                            if component.getDimension("mult") != 1
+                        ]
+                    )
 
                 cellRegions = []
                 for location in component.spatialLocator:
                     if self.r.core.geomType == armi.reactor.geometry.GeomType.HEX:
-                        origin = (location[0]*latticePitch+location[1]*.5*latticePitch, location[1]*3**.5*latticePitch)
+                        origin = (
+                            location[0] * latticePitch + location[1] * 0.5 * latticePitch,
+                            location[1] * 3**0.5 * latticePitch,
+                        )
                     elif self.r.core.geomType == armi.reactor.geometry.GeomType.CARTESIAN:
-                        origin = (location[0]*latticePitch[0], location[1]*latticePitch[1])
+                        origin = (location[0] * latticePitch[0], location[1] * latticePitch[1])
                     else:
                         raise TypeError("Unsupported geometry type")
 
-                    cellRegions.append(buildCellRegion(component, bottomPlane=blockBottomPlane, topPlane=blockTopPlane, origin=origin))
-                cell = openmc.Cell(name=component.getName(),
-                                   fill=material,
-                                   region=openmc.Union(cellRegions))
+                    cellRegions.append(
+                        buildCellRegion(
+                            component,
+                            bottomPlane=blockBottomPlane,
+                            topPlane=blockTopPlane,
+                            origin=origin,
+                        )
+                    )
+                cell = openmc.Cell(
+                    name=component.getName(), fill=material, region=openmc.Union(cellRegions)
+                )
             return cell
 
         def cartesianToRing(cartesianIndices):
@@ -139,50 +188,53 @@ class OpenMCWriter:
             x = cartesianIndices[0]
             y = cartesianIndices[1]
 
-            if x*y>=0:
-                ring = abs(x)+abs(y)
-                if x>0 or y>0:
-                    pos = 6*ring/6-x
-                elif x<0 or y<0:
-                    pos = 6*ring*3/6+abs(y)
+            if x * y >= 0:
+                ring = abs(x) + abs(y)
+                if x > 0 or y > 0:
+                    pos = 6 * ring / 6 - x
+                elif x < 0 or y < 0:
+                    pos = 6 * ring * 3 / 6 + abs(y)
                 else:
                     pos = 0
 
-            elif x*y<0:
+            elif x * y < 0:
                 ring = max([abs(x), abs(y)])
-                if abs(x)==ring:
-                    if x<0:
-                        pos = 6*ring*3/6-y
+                if abs(x) == ring:
+                    if x < 0:
+                        pos = 6 * ring * 3 / 6 - y
                     else:
-                        pos = 6*ring-abs(y)
+                        pos = 6 * ring - abs(y)
                 else:
-                    if y>0:
-                        pos = 6*ring*1/6+abs(x)
+                    if y > 0:
+                        pos = 6 * ring * 1 / 6 + abs(x)
                     else:
-                        pos = 6*ring*4/6+x
+                        pos = 6 * ring * 4 / 6 + x
 
             # OpenMC's ring system starts at the top and goes clockwise
-            lenRing = max([ring*6, 1])
-            pos = (lenRing+ring-pos)%lenRing
+            lenRing = max([ring * 6, 1])
+            pos = (lenRing + ring - pos) % lenRing
             return [ring, int(pos)]
 
         def buildRings(numRings, universe):
             """Assemble rings for use in openmc.HexLattice"""
             # Note: Need to rings.reverse() before assigning to lattice.universes. Not doing it here keeps indexing easy.
-            rings = [None]*numRings
+            rings = [None] * numRings
             rings[0] = [universe]
             ringLength = 6
             for i in range(1, numRings):
-                rings[i] = [universe]*ringLength
+                rings[i] = [universe] * ringLength
                 ringLength += 6
             return rings
 
         def buildComponentMaterial(component):
             """Build OpenMC material for ARMI component"""
-            if component.material.name=="Void":
+            if component.material.name == "Void":
                 return None
             componentMaterial = openmc.Material(name=component.material.name)
-            componentMaterial.set_density("g/cm3", component.material.getProperty("pseudoDensity", Tc=component.temperatureInC))
+            componentMaterial.set_density(
+                "g/cm3",
+                component.material.getProperty("pseudoDensity", Tc=component.temperatureInC),
+            )
 
             componentNuclides = component.getNuclides()
             componentNuclideDensities = component.getNuclideNumberDensities(componentNuclides)
@@ -190,9 +242,13 @@ class OpenMCWriter:
 
             for i, nuclideName in enumerate(componentNuclides):
                 nuclide = nuclideBases.byName[nuclideName]
-                if nuclide.a>0:  # ignore lumped fission products and dummy nuclides for now
+                if nuclide.a > 0:  # ignore lumped fission products and dummy nuclides for now
                     nuclideGNDSName = openmc.data.gnds_name(Z=nuclide.z, A=nuclide.a)
-                    componentMaterial.add_nuclide(nuclideGNDSName, componentNuclideDensities[i]/totalComponentNuclideDensity, 'ao')
+                    componentMaterial.add_nuclide(
+                        nuclideGNDSName,
+                        componentNuclideDensities[i] / totalComponentNuclideDensity,
+                        "ao",
+                    )
             return componentMaterial
 
         runLog.info("Writing geometry, materials, and plots...")
@@ -201,66 +257,86 @@ class OpenMCWriter:
         materials = openmc.Materials()
         emptyMaterial = openmc.Material()
         plotColors = dict()
-        colorLookup = {"HT9": "steelblue",
-                       "UZr": "green",
-                       "UO2": "green",
-                       "UraniumOxide": "green",
-                       "Sodium": "antiquewhite",
-                       "Custom": "purple",
-                       "B4C": "black",
-                       "SaturatedWater": "blue"}
+        colorLookup = {
+            "HT9": "steelblue",
+            "UZr": "green",
+            "UO2": "green",
+            "UraniumOxide": "green",
+            "Sodium": "antiquewhite",
+            "Custom": "purple",
+            "B4C": "black",
+            "SaturatedWater": "blue",
+        }
 
         numRings = core.numRings
-        boundingCellBottomPlane = openmc.ZPlane(z0=0.0, boundary_type='vacuum')
-        boundingCellTopPlane = openmc.ZPlane(z0=max([assembly.getHeight() for assembly in core]), boundary_type='vacuum')
+        boundingCellBottomPlane = openmc.ZPlane(z0=0.0, boundary_type="vacuum")
+        boundingCellTopPlane = openmc.ZPlane(
+            z0=max([assembly.getHeight() for assembly in core]), boundary_type="vacuum"
+        )
 
         if core.geomType == armi.reactor.geometry.GeomType.HEX:
 
             boundingCylinderRadius = core.getCoreRadius()
-            boundingCylinder = openmc.ZCylinder(r=boundingCylinderRadius, boundary_type='vacuum')
+            boundingCylinder = openmc.ZCylinder(r=boundingCylinderRadius, boundary_type="vacuum")
 
-            if core.symmetry.domain==armi.reactor.geometry.DomainType.FULL_CORE:
-                boundingCellRegion = -boundingCylinder & +boundingCellBottomPlane & -boundingCellTopPlane
+            if core.symmetry.domain == armi.reactor.geometry.DomainType.FULL_CORE:
+                boundingCellRegion = (
+                    -boundingCylinder & +boundingCellBottomPlane & -boundingCellTopPlane
+                )
 
-            if core.symmetry.domain==armi.reactor.geometry.DomainType.THIRD_CORE:
-                armi.reactor.converters.geometryConverters.EdgeAssemblyChanger().addEdgeAssemblies(core)
-                periodicPlane0 = openmc.Plane(a=0.0,b=1.0,c=0.0,d=0.0)
-                periodicPlane1 = openmc.Plane(a=3.0**.5,b=1.0,c=0.0,d=0.0)
+            if core.symmetry.domain == armi.reactor.geometry.DomainType.THIRD_CORE:
+                armi.reactor.converters.geometryConverters.EdgeAssemblyChanger().addEdgeAssemblies(
+                    core
+                )
+                periodicPlane0 = openmc.Plane(a=0.0, b=1.0, c=0.0, d=0.0)
+                periodicPlane1 = openmc.Plane(a=3.0**0.5, b=1.0, c=0.0, d=0.0)
 
-                if core.symmetry.boundary==armi.reactor.geometry.BoundaryType.PERIODIC:
-                    periodicPlane0.boundary_type = 'periodic'
-                    periodicPlane1.boundary_type = 'periodic'
+                if core.symmetry.boundary == armi.reactor.geometry.BoundaryType.PERIODIC:
+                    periodicPlane0.boundary_type = "periodic"
+                    periodicPlane1.boundary_type = "periodic"
 
-                if core.symmetry.boundary==armi.reactor.geometry.BoundaryType.REFLECTIVE:
-                    periodicPlane0.boundary_type = 'reflective'
-                    periodicPlane1.boundary_type = 'reflective'
-                boundingCellRegion = -boundingCylinder & +periodicPlane0 & +periodicPlane1 & +boundingCellBottomPlane & -boundingCellTopPlane
+                if core.symmetry.boundary == armi.reactor.geometry.BoundaryType.REFLECTIVE:
+                    periodicPlane0.boundary_type = "reflective"
+                    periodicPlane1.boundary_type = "reflective"
+                boundingCellRegion = (
+                    -boundingCylinder
+                    & +periodicPlane0
+                    & +periodicPlane1
+                    & +boundingCellBottomPlane
+                    & -boundingCellTopPlane
+                )
 
             emptyCellRegion = -boundingCylinder & +boundingCellBottomPlane & -boundingCellTopPlane
-            emptyCell = openmc.Cell(region = emptyCellRegion)
+            emptyCell = openmc.Cell(region=emptyCellRegion)
 
             # Create blank list of assembly universes for the lattice - we will fill in universes individually later
             emptyUniverse = openmc.Universe(cells=[emptyCell])
             assemblyLatticeIndices = buildRings(numRings, emptyUniverse)
 
         elif core.geomType == armi.reactor.geometry.GeomType.CARTESIAN:
-            boundingCylinderRadius = core.getAssemblyPitch()[0]*core.numRings*2**.5
-            boundingCylinder = openmc.ZCylinder(r=boundingCylinderRadius, boundary_type='vacuum')
+            boundingCylinderRadius = core.getAssemblyPitch()[0] * core.numRings * 2**0.5
+            boundingCylinder = openmc.ZCylinder(r=boundingCylinderRadius, boundary_type="vacuum")
 
-            if core.symmetry.domain==armi.reactor.geometry.DomainType.QUARTER_CORE:
-                periodicPlane0 = openmc.Plane(a=0.0,b=1.0,c=0.0,d=0.0)
-                periodicPlane1 = openmc.Plane(a=1.0,b=0.0,c=0.0,d=0.0)
-                periodicPlane0.boundary_type = 'periodic'
-                periodicPlane1.boundary_type = 'periodic'
-                boundingCellRegion = -boundingCylinder & +periodicPlane0 & +periodicPlane1 & +boundingCellBottomPlane & -boundingCellTopPlane
+            if core.symmetry.domain == armi.reactor.geometry.DomainType.QUARTER_CORE:
+                periodicPlane0 = openmc.Plane(a=0.0, b=1.0, c=0.0, d=0.0)
+                periodicPlane1 = openmc.Plane(a=1.0, b=0.0, c=0.0, d=0.0)
+                periodicPlane0.boundary_type = "periodic"
+                periodicPlane1.boundary_type = "periodic"
+                boundingCellRegion = (
+                    -boundingCylinder
+                    & +periodicPlane0
+                    & +periodicPlane1
+                    & +boundingCellBottomPlane
+                    & -boundingCellTopPlane
+                )
 
             emptyCellRegion = -boundingCylinder & +boundingCellBottomPlane & -boundingCellTopPlane
-            emptyCell = openmc.Cell(region = emptyCellRegion)
+            emptyCell = openmc.Cell(region=emptyCellRegion)
 
             emptyUniverse = openmc.Universe(cells=[emptyCell])
             assemblyLatticeIndices = []
             for ring in range(numRings):
-                assemblyLatticeIndices.append([emptyUniverse]*numRings)
+                assemblyLatticeIndices.append([emptyUniverse] * numRings)
         else:
             raise TypeError("Unsupported geometry type")
 
@@ -271,28 +347,43 @@ class OpenMCWriter:
 
             # Create ZPlanes between blocks
             z0 = 0.0
-            ZPlanes=[openmc.ZPlane(z0=z0, boundary_type='vacuum')]
+            ZPlanes = [openmc.ZPlane(z0=z0, boundary_type="vacuum")]
             for block in assembly:
                 z0 += block.getHeight()
-                ZPlanes.append(openmc.ZPlane(z0=z0, boundary_type='transmission'))
-            ZPlanes[-1].boundary_type = 'vacuum' # Reset top plane boundary condition to vacuum
+                ZPlanes.append(openmc.ZPlane(z0=z0, boundary_type="transmission"))
+            ZPlanes[-1].boundary_type = "vacuum"  # Reset top plane boundary condition to vacuum
 
             blockCellsInAssembly = []
             for i, block in enumerate(assembly):
                 blockBottomPlane = ZPlanes[i]
-                blockTopPlane = ZPlanes[i+1]
+                blockTopPlane = ZPlanes[i + 1]
 
                 blockWithoutHelices = blendHelixComponentsIntoCoolant(block)
 
-                blockHasDerivedShapeComponent = any([isinstance(component, armi.reactor.components.DerivedShape) for component in blockWithoutHelices])
+                blockHasDerivedShapeComponent = any(
+                    [
+                        isinstance(component, armi.reactor.components.DerivedShape)
+                        for component in blockWithoutHelices
+                    ]
+                )
                 # Get DerivedShape component. We need to set its region last
                 if blockHasDerivedShapeComponent:
-                    derivedShapeComponent = [component for component in blockWithoutHelices if isinstance(component, armi.reactor.components.DerivedShape)][0]
+                    derivedShapeComponent = [
+                        component
+                        for component in blockWithoutHelices
+                        if isinstance(component, armi.reactor.components.DerivedShape)
+                    ][0]
                     derivedShapeComponentMaterial = buildComponentMaterial(derivedShapeComponent)
                     if derivedShapeComponentMaterial is not None:
                         materials.append(derivedShapeComponentMaterial)
-                        plotColors[derivedShapeComponentMaterial.id] = colorLookup[derivedShapeComponent.material.name]
-                    blockMinusDerivedShape = [component for component in blockWithoutHelices if not isinstance(component, armi.reactor.components.DerivedShape)]
+                        plotColors[derivedShapeComponentMaterial.id] = colorLookup[
+                            derivedShapeComponent.material.name
+                        ]
+                    blockMinusDerivedShape = [
+                        component
+                        for component in blockWithoutHelices
+                        if not isinstance(component, armi.reactor.components.DerivedShape)
+                    ]
                 else:
                     blockMinusDerivedShape = blockWithoutHelices
                     derivedShapeComponentMaterial = None
@@ -312,57 +403,96 @@ class OpenMCWriter:
                     multGroups[mult].append(component)
 
                 # If any components have mult>1, we need a cell filled with a lattice of them
-                if len(multGroups)==2:
+                if len(multGroups) == 2:
                     if block.hasPinPitch():
                         latticePitch = block.getPinPitch()
                     else:
-                        latticePitch = 1.2*max([[component.getBoundingCircleOuterDiameter() for component in multGroups[multGroup]] for multGroup in multGroups if multGroup!=1])[0]
+                        latticePitch = (
+                            1.2
+                            * max(
+                                [
+                                    [
+                                        component.getBoundingCircleOuterDiameter()
+                                        for component in multGroups[multGroup]
+                                    ]
+                                    for multGroup in multGroups
+                                    if multGroup != 1
+                                ]
+                            )[0]
+                        )
 
                     if core.geomType == armi.reactor.geometry.GeomType.HEX:
-                        totalSlots = [mult for mult in multGroups if mult>1][0]
+                        totalSlots = [mult for mult in multGroups if mult > 1][0]
 
                         # Determine number of rings -> solve mult=1+6*(nRings-1)(nRings)/2
-                        nRings = math.ceil(.5*(1+(1+4/3*(totalSlots-1))**.5))
+                        nRings = math.ceil(0.5 * (1 + (1 + 4 / 3 * (totalSlots - 1)) ** 0.5))
                         blockLattice = openmc.HexLattice()
                         blockLattice.pitch = [latticePitch]
-                        blockLattice.orientation = 'x'
-                        blockLattice.center = (0,0)
+                        blockLattice.orientation = "x"
+                        blockLattice.center = (0, 0)
                         blockLatticeIndices = buildRings(nRings, emptyUniverse)
 
                     elif core.geomType == armi.reactor.geometry.GeomType.CARTESIAN:
                         boundingIndices = block.spatialGrid.getIndexBounds()
-                        blockLatticeIndicesOffset = (boundingIndices[0][0],boundingIndices[1][0])
+                        blockLatticeIndicesOffset = (boundingIndices[0][0], boundingIndices[1][0])
                         blockLattice = openmc.RectLattice()
                         blockLattice.pitch = latticePitch
-                        blockLattice.lower_left = (latticePitch[0]*boundingIndices[0][0],latticePitch[1]*boundingIndices[1][0])
+                        blockLattice.lower_left = (
+                            latticePitch[0] * boundingIndices[0][0],
+                            latticePitch[1] * boundingIndices[1][0],
+                        )
                         blockLatticeIndices = []
-                        for ring in range(boundingIndices[1][1]-boundingIndices[1][0]-1):
-                            blockLatticeIndices.append([emptyUniverse]*(boundingIndices[0][1]-boundingIndices[0][0]-1))
+                        for ring in range(boundingIndices[1][1] - boundingIndices[1][0] - 1):
+                            blockLatticeIndices.append(
+                                [emptyUniverse]
+                                * (boundingIndices[0][1] - boundingIndices[0][0] - 1)
+                            )
 
                     for mult in multGroups:
-                        if mult>1:
+                        if mult > 1:
                             componentCellsInMultGroupUniverse = []
                             for component in multGroups[mult]:
                                 componentMaterial = buildComponentMaterial(component)
-                                cell = openmc.Cell(name=component.getName(),
-                                                   fill=componentMaterial,
-                                                   region=buildCellRegion(component, bottomPlane=blockBottomPlane, topPlane=blockTopPlane))
+                                cell = openmc.Cell(
+                                    name=component.getName(),
+                                    fill=componentMaterial,
+                                    region=buildCellRegion(
+                                        component,
+                                        bottomPlane=blockBottomPlane,
+                                        topPlane=blockTopPlane,
+                                    ),
+                                )
                                 if componentMaterial is not None:
                                     materials.append(componentMaterial)
-                                    plotColors[componentMaterial.id] = colorLookup[component.material.name]
+                                    plotColors[componentMaterial.id] = colorLookup[
+                                        component.material.name
+                                    ]
                                 componentCellsInMultGroupUniverse.append(cell)
                             if blockHasDerivedShapeComponent:
                                 # Fill unused space in lattice with derivedShapeComponentMaterial
-                                derivedShapeComponentLatticeCell = openmc.Cell(name=derivedShapeComponent.getName(),
-                                                                               fill=derivedShapeComponentMaterial,
-                                                                               region=~openmc.Union([cell.region for cell in componentCellsInMultGroupUniverse]) & +blockBottomPlane & -blockTopPlane)
-                                componentCellsInMultGroupUniverse.append(derivedShapeComponentLatticeCell)
+                                derivedShapeComponentLatticeCell = openmc.Cell(
+                                    name=derivedShapeComponent.getName(),
+                                    fill=derivedShapeComponentMaterial,
+                                    region=~openmc.Union(
+                                        [cell.region for cell in componentCellsInMultGroupUniverse]
+                                    )
+                                    & +blockBottomPlane
+                                    & -blockTopPlane,
+                                )
+                                componentCellsInMultGroupUniverse.append(
+                                    derivedShapeComponentLatticeCell
+                                )
 
-                            multGroupUniverse = openmc.Universe(name="multGroup"+str(mult), cells=componentCellsInMultGroupUniverse)
+                            multGroupUniverse = openmc.Universe(
+                                name="multGroup" + str(mult),
+                                cells=componentCellsInMultGroupUniverse,
+                            )
 
                             """if spatialLocator is a multiIndexLocation, use it. Otherwise, assume all blockLatticeUniverses are multGroupUniverse"""
                             multGroupIndices = multGroups[mult][0].spatialLocator
-                            if not isinstance(multGroupIndices, armi.reactor.grids.MultiIndexLocation):
+                            if not isinstance(
+                                multGroupIndices, armi.reactor.grids.MultiIndexLocation
+                            ):
                                 # Assume every universe in blockLattice is a multGroupUniverse
                                 for rowIndex, row in enumerate(blockLatticeIndices):
                                     for colIndex in range(len(row)):
@@ -370,39 +500,59 @@ class OpenMCWriter:
                             else:
                                 if core.geomType == armi.reactor.geometry.GeomType.CARTESIAN:
                                     for location in multGroupIndices:
-                                        blockLatticeIndices[location[0]][location[1]] = multGroupUniverse
+                                        blockLatticeIndices[location[0]][
+                                            location[1]
+                                        ] = multGroupUniverse
                                 if core.geomType == armi.reactor.geometry.GeomType.HEX:
                                     for location in multGroupIndices:
                                         ringIndices = cartesianToRing(location[0:2])
-                                        blockLatticeIndices[ringIndices[0]][ringIndices[1]] = multGroupUniverse
+                                        blockLatticeIndices[ringIndices[0]][
+                                            ringIndices[1]
+                                        ] = multGroupUniverse
 
                     if core.geomType == armi.reactor.geometry.GeomType.HEX:
                         blockLatticeIndices.reverse()
                     blockLattice.universes = blockLatticeIndices
 
-                    blockLatticeOuterCell = openmc.Cell(region=+blockBottomPlane & -blockTopPlane & -boundingCylinder,
-                                                        fill=derivedShapeComponentMaterial)
+                    blockLatticeOuterCell = openmc.Cell(
+                        region=+blockBottomPlane & -blockTopPlane & -boundingCylinder,
+                        fill=derivedShapeComponentMaterial,
+                    )
                     blockLatticeOuterUniverse = openmc.Universe(cells=[blockLatticeOuterCell])
                     blockLattice.outer = blockLatticeOuterUniverse
                     # Need cell to fill with lattice
                     # Get smallest mult 1 component - blockLatticeCell will have region inside it
-                    mult1ComponentInnerDiameters = [component.getCircleInnerDiameter() for component in multGroups[1]]
-                    smallestMult1Component = multGroups[1][min(range(len(mult1ComponentInnerDiameters)), key=mult1ComponentInnerDiameters.__getitem__)]
+                    mult1ComponentInnerDiameters = [
+                        component.getCircleInnerDiameter() for component in multGroups[1]
+                    ]
+                    smallestMult1Component = multGroups[1][
+                        min(
+                            range(len(mult1ComponentInnerDiameters)),
+                            key=mult1ComponentInnerDiameters.__getitem__,
+                        )
+                    ]
                     if isinstance(smallestMult1Component, basicShapes.Circle):
-                        innerCylinder = openmc.ZCylinder(r=smallestMult1Component.getDimension("id")/2-.05)
+                        innerCylinder = openmc.ZCylinder(
+                            r=smallestMult1Component.getDimension("id") / 2 - 0.05
+                        )
                         blockLatticeCellRegion = -innerCylinder & +blockBottomPlane & -blockTopPlane
                     elif isinstance(smallestMult1Component, basicShapes.Hexagon):
-                        innerHexPrism = openmc.model.hexagonal_prism(edge_length=smallestMult1Component.getDimension("ip")/3**.5-.05, orientation='x')
+                        innerHexPrism = openmc.model.hexagonal_prism(
+                            edge_length=smallestMult1Component.getDimension("ip") / 3**0.5 - 0.05,
+                            orientation="x",
+                        )
                         blockLatticeCellRegion = innerHexPrism & +blockBottomPlane & -blockTopPlane
                     elif isinstance(smallestMult1Component, basicShapes.Rectangle):
-                        innerRectPrism = openmc.model.rectangular_prism(width=smallestMult1Component.getDimension("widthInner")-.05,
-                                                                        height=smallestMult1Component.getDimension("lengthInner")-.05)
+                        innerRectPrism = openmc.model.rectangular_prism(
+                            width=smallestMult1Component.getDimension("widthInner") - 0.05,
+                            height=smallestMult1Component.getDimension("lengthInner") - 0.05,
+                        )
                         blockLatticeCellRegion = innerRectPrism & +blockBottomPlane & -blockTopPlane
                     else:
                         raise NotImplementedError("Shape type not supported yet")
-                    blockLatticeCell = openmc.Cell(name="blockLattice",
-                                                       fill = blockLattice,
-                                                       region = blockLatticeCellRegion)
+                    blockLatticeCell = openmc.Cell(
+                        name="blockLattice", fill=blockLattice, region=blockLatticeCellRegion
+                    )
                     componentCellsInBlock.append(blockLatticeCell)
 
                     remainingComponents = multGroups[1]
@@ -412,19 +562,28 @@ class OpenMCWriter:
                 # If component cell surfaces are perfectly coincident with lattice boundaries, it's possible for a particle to get lost by hitting a corner just right.
                 # Fix by adding a buffer to the outside of the largest component (e.g. intercoolant). Does not change effective geometry in the simulation.
                 # This code should be migrated to proper plugin geometryTransformations because we do not undo this transformation anywhere.
-                remainingComponentOuterDiameters = [component.getBoundingCircleOuterDiameter() for component in remainingComponents]
-                largestRemainingComponent = remainingComponents[max(range(len(remainingComponentOuterDiameters)), key=remainingComponentOuterDiameters.__getitem__)]
+                remainingComponentOuterDiameters = [
+                    component.getBoundingCircleOuterDiameter() for component in remainingComponents
+                ]
+                largestRemainingComponent = remainingComponents[
+                    max(
+                        range(len(remainingComponentOuterDiameters)),
+                        key=remainingComponentOuterDiameters.__getitem__,
+                    )
+                ]
                 componentMaterial = buildComponentMaterial(largestRemainingComponent)
                 if componentMaterial is not None:
-                        materials.append(componentMaterial)
-                        plotColors[componentMaterial.id] = colorLookup[component.material.name]
-                cell = buildCell(largestRemainingComponent,
-                                 material=componentMaterial,
-                                 block=block,
-                                 bottomPlane=blockBottomPlane,
-                                 topPlane=blockTopPlane,
-                                 origin=(0.0,0.0),
-                                 outsideBuffer=0.01)
+                    materials.append(componentMaterial)
+                    plotColors[componentMaterial.id] = colorLookup[component.material.name]
+                cell = buildCell(
+                    largestRemainingComponent,
+                    material=componentMaterial,
+                    block=block,
+                    bottomPlane=blockBottomPlane,
+                    topPlane=blockTopPlane,
+                    origin=(0.0, 0.0),
+                    outsideBuffer=0.01,
+                )
                 componentCellsInBlock.append(cell)
                 remainingComponents.remove(largestRemainingComponent)
 
@@ -433,30 +592,46 @@ class OpenMCWriter:
                     if componentMaterial is not None:
                         materials.append(componentMaterial)
                         plotColors[componentMaterial.id] = colorLookup[component.material.name]
-                    cell = buildCell(component,
-                                     material=componentMaterial,
-                                     block=block,
-                                     bottomPlane=blockBottomPlane,
-                                     topPlane=blockTopPlane,
-                                     origin=(0.0,0.0),
-                                     outsideBuffer=0.0)
+                    cell = buildCell(
+                        component,
+                        material=componentMaterial,
+                        block=block,
+                        bottomPlane=blockBottomPlane,
+                        topPlane=blockTopPlane,
+                        origin=(0.0, 0.0),
+                        outsideBuffer=0.0,
+                    )
                     componentCellsInBlock.append(cell)
 
                 if blockHasDerivedShapeComponent:
                     # Set region for DerivedShape component - there should be a max of one per block
-                    derivedShapeComponentCell = openmc.Cell(name=derivedShapeComponent.getName(),
-                                                            fill = derivedShapeComponentMaterial,
-                                                            region = ~openmc.Union([blockCell.region for blockCell in componentCellsInBlock]) & +blockBottomPlane & -blockTopPlane)
+                    derivedShapeComponentCell = openmc.Cell(
+                        name=derivedShapeComponent.getName(),
+                        fill=derivedShapeComponentMaterial,
+                        region=~openmc.Union(
+                            [blockCell.region for blockCell in componentCellsInBlock]
+                        )
+                        & +blockBottomPlane
+                        & -blockTopPlane,
+                    )
                     componentCellsInBlock.append(derivedShapeComponentCell)
                 else:
                     # If there's no DerivedShape component, add an empty cell in unoccupied region in case ComponentCellsInBlock doesn't fill its assemblyLattice cell
-                    emptyComponentCell = openmc.Cell(name='emptyComponent',
-                                                          region = ~openmc.Union([blockCell.region for blockCell in componentCellsInBlock]) & +blockBottomPlane & -blockTopPlane)
+                    emptyComponentCell = openmc.Cell(
+                        name="emptyComponent",
+                        region=~openmc.Union(
+                            [blockCell.region for blockCell in componentCellsInBlock]
+                        )
+                        & +blockBottomPlane
+                        & -blockTopPlane,
+                    )
                     componentCellsInBlock.append(emptyComponentCell)
-                blockUniverse = openmc.Universe(cells = componentCellsInBlock)
-                blockUniverseCell = openmc.Cell(name=block.getName(),
-                                                fill=blockUniverse,
-                                                region=openmc.Union([blockCell.region for blockCell in componentCellsInBlock]))
+                blockUniverse = openmc.Universe(cells=componentCellsInBlock)
+                blockUniverseCell = openmc.Cell(
+                    name=block.getName(),
+                    fill=blockUniverse,
+                    region=openmc.Union([blockCell.region for blockCell in componentCellsInBlock]),
+                )
 
                 blockCellsInAssembly.append(blockUniverseCell)
                 self.blockFilterCells.append(blockUniverseCell)
@@ -475,15 +650,18 @@ class OpenMCWriter:
         # Create core lattice
         if core.geomType == armi.reactor.geometry.GeomType.HEX:
             lattice = openmc.HexLattice()
-            lattice.center = (0,0)
+            lattice.center = (0, 0)
 
             lattice.pitch = [core.getAssemblyPitch()]
         elif core.geomType == armi.reactor.geometry.GeomType.CARTESIAN:
             lattice = openmc.RectLattice()
-            if core.symmetry.domain==armi.reactor.geometry.DomainType.QUARTER_CORE:
+            if core.symmetry.domain == armi.reactor.geometry.DomainType.QUARTER_CORE:
                 lattice.lower_left = (0.0, 0.0)
             else:
-                lattice.lower_left = (-core.getAssemblyPitch()[0]*(core.numRings/2),-core.getAssemblyPitch()[1]*(core.numRings/2))
+                lattice.lower_left = (
+                    -core.getAssemblyPitch()[0] * (core.numRings / 2),
+                    -core.getAssemblyPitch()[1] * (core.numRings / 2),
+                )
             lattice.pitch = [p for p in core.getAssemblyPitch()]
         else:
             raise TypeError("Unsupported geometry type")
@@ -493,21 +671,21 @@ class OpenMCWriter:
         lattice.outer = emptyUniverse
 
         # Create root universe
-        rootCell = openmc.Cell(name="rootCell", fill=lattice, region = boundingCellRegion)
+        rootCell = openmc.Cell(name="rootCell", fill=lattice, region=boundingCellRegion)
         rootUniverse = openmc.Universe(cells=[rootCell])
 
         # Write geometry to xml
         geometry = openmc.Geometry(rootUniverse)
-        geometry.merge_surfaces=True # merge redundant surfaces
+        geometry.merge_surfaces = True  # merge redundant surfaces
 
         # Write plots xml file
         plot = openmc.Plot()
-        plot.basis = 'xy'
+        plot.basis = "xy"
         plot.filename = self.r.getName()
         plot.width = (boundingCylinderRadius, boundingCylinderRadius)
         plot.pixels = (100, 100)
         plot.origin = (0.0, 0.0, 20.0)
-        plot.color_by = 'material'
+        plot.color_by = "material"
         plot.colors = plotColors
         plots = openmc.Plots([plot])
 
@@ -519,22 +697,26 @@ class OpenMCWriter:
         """Write the OpenMC settings input file."""
         runLog.info("Writing settings...")
         settings = openmc.Settings()
-        settings.run_mode = 'eigenvalue'
+        settings.run_mode = "eigenvalue"
         bbHeight = max([assembly.getHeight() for assembly in self.r.core])
         if self.r.core.geomType == armi.reactor.geometry.GeomType.HEX:
             boundingCylinderRadius = self.r.core.getCoreRadius()
         elif self.r.core.geomType == armi.reactor.geometry.GeomType.CARTESIAN:
-            boundingCylinderRadius = self.r.core.getAssemblyPitch()[0]*self.r.core.numRings*2**.5
-        point = openmc.stats.Box(lower_left=(-boundingCylinderRadius,-boundingCylinderRadius,0.0), 
-                                 upper_right=(boundingCylinderRadius,boundingCylinderRadius,bbHeight),
-                                 only_fissionable=True)
+            boundingCylinderRadius = (
+                self.r.core.getAssemblyPitch()[0] * self.r.core.numRings * 2**0.5
+            )
+        point = openmc.stats.Box(
+            lower_left=(-boundingCylinderRadius, -boundingCylinderRadius, 0.0),
+            upper_right=(boundingCylinderRadius, boundingCylinderRadius, bbHeight),
+            only_fissionable=True,
+        )
         settings.source = openmc.IndependentSource(space=point)
         settings.batches = self.options.nBatches
         settings.inactive = self.options.nInactiveBatches
         settings.particles = self.options.nParticles
         settings.generations_per_batch = 1
-        settings.temperature = {'method': 'interpolation', 'default': 350.0}
-        settings.output = {'tallies': False, 'summary': False}
+        settings.temperature = {"method": "interpolation", "default": 350.0}
+        settings.output = {"tallies": False, "summary": False}
         settings.verbosity = self.options.openmcVerbosity
         entropyMesh = openmc.RegularMesh()
         bbWidth = boundingCylinderRadius
@@ -555,7 +737,7 @@ class OpenMCWriter:
         if self.r.core.geomType == armi.reactor.geometry.GeomType.HEX:
             bbWidth = self.r.core.getCoreRadius()
         elif self.r.core.geomType == armi.reactor.geometry.GeomType.CARTESIAN:
-            bbWidth = self.r.core.getAssemblyPitch()[0]*self.r.core.numRings
+            bbWidth = self.r.core.getAssemblyPitch()[0] * self.r.core.numRings
 
         tallyMesh = openmc.RegularMesh()
         bbHeight = max([assembly.getHeight() for assembly in self.r.core])
@@ -564,41 +746,43 @@ class OpenMCWriter:
         tallyMesh.dimension = tuple(self.options.tallyMeshDimension)
         meshFilter = openmc.MeshFilter(mesh=tallyMesh, filter_id=101)
 
-        energyGroupStructure = parseEnergyGroupStructure(energyGroups.getGroupStructure(self.options.groupStructure))
+        energyGroupStructure = parseEnergyGroupStructure(
+            energyGroups.getGroupStructure(self.options.groupStructure)
+        )
         energyFilter = openmc.EnergyFilter(energyGroupStructure, filter_id=102)
-        blockFilter = openmc.CellFilter(bins = self.blockFilterCells, filter_id=103)
+        blockFilter = openmc.CellFilter(bins=self.blockFilterCells, filter_id=103)
 
         fissionTally = openmc.Tally(101, name="fission rate")
-        fissionTally.scores = ['fission']
-        fissionTally.nuclides = ['U235', 'U238']
+        fissionTally.scores = ["fission"]
+        fissionTally.nuclides = ["U235", "U238"]
         fissionTally.filters = [meshFilter]
         tallies.append(fissionTally)
 
         blockFluxTally = openmc.Tally(102, name="block filter multigroup flux")
-        blockFluxTally.scores = ['flux']
+        blockFluxTally.scores = ["flux"]
         blockFluxTally.filters = [blockFilter, energyFilter]
         tallies.append(blockFluxTally)
 
         meshFluxTally = openmc.Tally(103, name="mesh filter multigroup flux")
-        meshFluxTally.scores = ['flux']
+        meshFluxTally.scores = ["flux"]
         meshFluxTally.filters = [meshFilter, energyFilter]
         tallies.append(meshFluxTally)
 
         powerTally = openmc.Tally(104, name="power")
-        powerTally.scores = ['heating-local']
+        powerTally.scores = ["heating-local"]
         powerTally.filters = [blockFilter]
         tallies.append(powerTally)
 
         absorptionTally = openmc.Tally(105, name="absorption")
-        absorptionTally.scores = ['absorption']
+        absorptionTally.scores = ["absorption"]
         absorptionTally.filters = [blockFilter]
         tallies.append(absorptionTally)
 
         tallies.export_to_xml()
+
 
 def parseEnergyGroupStructure(energyGroupStructure):
     """Convert ARMI group structure to openmc group structure"""
     energyGroupStructure.append(0.0)
     energyGroupStructure.reverse()
     return energyGroupStructure
-

--- a/armicontrib/armiopenmc/settings.py
+++ b/armicontrib/armiopenmc/settings.py
@@ -97,77 +97,80 @@ def defineSettings():
         ),
         setting.Setting(
             CONF_N_BATCHES,
-            default = 100,
-            label = "Number of batches",
-            description=("Defines number of batches to be run in an OpenMC simulation.")
+            default=100,
+            label="Number of batches",
+            description=("Defines number of batches to be run in an OpenMC simulation."),
         ),
         setting.Setting(
             CONF_N_INACTIVE,
-            default = 10,
-            label = "Number of inactive batches",
-            description=("Defines number of inactive batches to run before recording results"
-            "in an OpenMC simulation."
-            )
+            default=10,
+            label="Number of inactive batches",
+            description=(
+                "Defines number of inactive batches to run before recording results"
+                "in an OpenMC simulation."
+            ),
         ),
         setting.Setting(
             CONF_N_PARTICLES,
-            default = 1000,
-            label = "Number of particles per generation",
-            description=("Defines number of particles to be simulated per generation"
-            "in OpenMC."
-            )
+            default=1000,
+            label="Number of particles per generation",
+            description=("Defines number of particles to be simulated per generation" "in OpenMC."),
         ),
         setting.Setting(
             CONF_TALLY_MESH_DIMENSION,
-            default = [10, 10, 10],
-            label = "Tally mesh dimension in OpenMC",
-            description=("Defines number of mesh cells in each dimension for fission and"
-            "heating tallies."
-            )
+            default=[10, 10, 10],
+            label="Tally mesh dimension in OpenMC",
+            description=(
+                "Defines number of mesh cells in each dimension for fission and" "heating tallies."
+            ),
         ),
         setting.Setting(
             CONF_ENTROPY_MESH_DIMENSION,
-            default = [10, 10, 10],
-            label = "Entropy mesh dimension in OpenMC",
-            description=("Defines number of mesh cells in each dimension for Shannon entropy"
-            "mesh. Used to measure source distribution convergence."
-            )
+            default=[10, 10, 10],
+            label="Entropy mesh dimension in OpenMC",
+            description=(
+                "Defines number of mesh cells in each dimension for Shannon entropy"
+                "mesh. Used to measure source distribution convergence."
+            ),
         ),
         setting.Setting(
             CONF_OPENMC_VERBOSITY,
-            default = 7,
-            label = "Verbosity of OpenMC output",
-            description=("OpenMC verbosity. From OpenMC documentation:"
-                         "1. don’t display any output"
-                         "2. only show OpenMC logo"
-                         "3. all of the above + headers"
-                         "4. all of the above + results"
-                         "5. all of the above + file I/O"
-                         "6. all of the above + timing statistics and initialization messages"
-                         "7. all of the above + k by generation"
-                         "9. all of the above + indicate when each particle starts"
-                         "10. all of the above + event information"
-            )
+            default=7,
+            label="Verbosity of OpenMC output",
+            description=(
+                "OpenMC verbosity. From OpenMC documentation:"
+                "1. don’t display any output"
+                "2. only show OpenMC logo"
+                "3. all of the above + headers"
+                "4. all of the above + results"
+                "5. all of the above + file I/O"
+                "6. all of the above + timing statistics and initialization messages"
+                "7. all of the above + k by generation"
+                "9. all of the above + indicate when each particle starts"
+                "10. all of the above + event information"
+            ),
         ),
         setting.Setting(
             CONF_N_OMP_THREADS,
-            default = os.cpu_count(),
-            label = "Number of OpenMP threads",
-            description=("Number of OpenMP threads to use in OpenMC."
-                         "Defaults to number of hardware threads available."
-            )
+            default=os.cpu_count(),
+            label="Number of OpenMP threads",
+            description=(
+                "Number of OpenMP threads to use in OpenMC."
+                "Defaults to number of hardware threads available."
+            ),
         ),
         setting.Setting(
             CONF_N_MPI_PROCESSES,
-            default = 1,
-            label = "Number of MPI processes",
-            description=("Number of MPI processes to use in OpenMC."
-                         "Each process will load its own copy of the problem geometry,"
-                         "So high numbers of MPI processes can use a lot of memory for"
-                         "complex geometry problems. Using shared-memory OpenMP threads"
-                         "can help mitigate this."
-            )
-        )
+            default=1,
+            label="Number of MPI processes",
+            description=(
+                "Number of MPI processes to use in OpenMC."
+                "Each process will load its own copy of the problem geometry,"
+                "So high numbers of MPI processes can use a lot of memory for"
+                "complex geometry problems. Using shared-memory OpenMP threads"
+                "can help mitigate this."
+            ),
+        ),
     ]
     return settings
 

--- a/openmcdemo/app.py
+++ b/openmcdemo/app.py
@@ -45,9 +45,10 @@ class ARMIOpenMCApp(armi.apps.App):
             armi.__version__
         )
 
+
 class OpenMCDemoPlugin(plugins.ArmiPlugin):
     """Plugin with OpenMC testing hooks"""
-    
+
     @staticmethod
     @plugins.HOOKIMPL
     def defineEntryPoints():

--- a/openmcdemo/cli/runFFTF.py
+++ b/openmcdemo/cli/runFFTF.py
@@ -40,7 +40,7 @@ from armiopenmc.settings import (
     CONF_ENTROPY_MESH_DIMENSION,
     CONF_OPENMC_VERBOSITY,
     CONF_N_OMP_THREADS,
-    CONF_N_MPI_PROCESSES
+    CONF_N_MPI_PROCESSES,
 )
 
 
@@ -106,18 +106,20 @@ class RunFFTF(EntryPoint):
         opts = executionOptions.OpenMCOptions()
         opts.fromReactor(o.r)
         opts.fromUserSettings(o.cs)
-        
+
         # Add custom tallies
         tallies = openmc.Tallies()
         mesh = openmc.RectilinearMesh()
-        mesh.x_grid = np.array([12.051/2,12.051*5/2])
-        mesh.y_grid = np.array([-12.051*3**.5,0.0])
-        mesh.z_grid = np.array([0.0,298.45/2-81,298.45/2-79,298.45/2-1,298.45/2+1,298.45])
+        mesh.x_grid = np.array([12.051 / 2, 12.051 * 5 / 2])
+        mesh.y_grid = np.array([-12.051 * 3**0.5, 0.0])
+        mesh.z_grid = np.array(
+            [0.0, 298.45 / 2 - 81, 298.45 / 2 - 79, 298.45 / 2 - 1, 298.45 / 2 + 1, 298.45]
+        )
         meshFilter = openmc.MeshFilter(mesh=mesh)
         energyGroupStructure = parseEnergyGroupStructure(energyGroups.getGroupStructure("ARMI33"))
         energyFilter = openmc.EnergyFilter(energyGroupStructure)
         meshFluxTally = openmc.Tally(1, name="custom tally")
-        meshFluxTally.scores = ['flux']
+        meshFluxTally.scores = ["flux"]
         meshFluxTally.filters = [meshFilter, energyFilter]
         tallies.append(meshFluxTally)
         opts.addTallies(tallies)
@@ -135,7 +137,6 @@ class RunFFTF(EntryPoint):
             norm = 1.0 / max(flux)
 
             return [f * norm for f in flux]
-
 
         def plotFlux(block, benchFlux, mcnpFlux, benchEnergy, title):
             armiEnergy = [e for e in energyGroups.getGroupStructure("ARMI33")]
@@ -157,7 +158,7 @@ class RunFFTF(EntryPoint):
             flux[-1] = flux[-2]
             energy = armiEnergy
             flux = normalizeFlux(flux, energy)
-            
+
             flux = np.array(flux).reshape((len(flux),))
 
             plt.step(energy, flux, label="ARMI OpenMC", where="post")
@@ -172,7 +173,6 @@ class RunFFTF(EntryPoint):
         midBenchEnergy = [erg * 1000.0 for erg in BENCH_MIDPLANE_ENERGY]
         lowBenchEnergy = [erg * 1000.0 for erg in BENCH_LOWER_ENERGY]
 
-
         grid = o.r.core.spatialGrid
         locator = grid.getLocatorFromRingAndPos(2, 6)
         a = o.r.core.childrenByLocator[locator]
@@ -182,8 +182,21 @@ class RunFFTF(EntryPoint):
         mid_block = test_blocks[3]
         low_block = test_blocks[1]
 
-        plotFlux(mid_block, BENCH_MIDPLANE_FLUX, MCNP_MIDPLANE_FLUX, midBenchEnergy, "Normalized Flux at Core Midplane")
-        plotFlux(low_block, BENCH_LOWER_FLUX, MCNP_LOWER_FLUX, lowBenchEnergy, "Normalized Flux at 80cm Below Core Midplane")
+        plotFlux(
+            mid_block,
+            BENCH_MIDPLANE_FLUX,
+            MCNP_MIDPLANE_FLUX,
+            midBenchEnergy,
+            "Normalized Flux at Core Midplane",
+        )
+        plotFlux(
+            low_block,
+            BENCH_LOWER_FLUX,
+            MCNP_LOWER_FLUX,
+            lowBenchEnergy,
+            "Normalized Flux at 80cm Below Core Midplane",
+        )
+
 
 """
 Published benchmark results for plotting in spectra.py


### PR DESCRIPTION
I was driving by and thought I'd add a code formatter to the project.

ARMI, and the rest of our ecosystem, uses the [black code formatter](https://black.readthedocs.io/en/stable/index.html).  Do you know it?

It makes it so we never again have to have a boring discussion about code formatting or style guides; we just automate all that.

And this little CI step will ensure any new PRs comply with the `black` formatting. If not, it fails, and the PR opener has to go and reformat their code:

```bash
black .
```