### PR TITLE
Fix namespace package imports.

### DIFF
--- a/armicontrib/armiopenmc/plugin.py
+++ b/armicontrib/armiopenmc/plugin.py
@@ -24,8 +24,8 @@ from armi import plugins
 from armi import interfaces
 from armi.physics.neutronics.globalFlux import globalFluxInterface
 
-from armiopenmc import settings
-from armiopenmc import schedulers
+from armicontrib.armiopenmc import settings
+from armicontrib.armiopenmc import schedulers
 
 ORDER = interfaces.STACK_ORDER.FLUX
 

--- a/armicontrib/armiopenmc/tests/test_constants.py
+++ b/armicontrib/armiopenmc/tests/test_constants.py
@@ -14,7 +14,7 @@
 """Tests of the constants module."""
 import unittest
 
-from armiopenmc import const
+from armicontrib.armiopenmc import const
 
 
 class TestConstants(unittest.TestCase):

--- a/openmcdemo/cli/runFFTF.py
+++ b/openmcdemo/cli/runFFTF.py
@@ -27,11 +27,11 @@ from armi.settings import caseSettings
 from armi.physics.neutronics import energyGroups
 from armi.reactor.flags import Flags
 from armi.physics.neutronics.settings import CONF_GROUP_STRUCTURE
-from armiopenmc.executers import OpenMCExecuter
-from armiopenmc.inputWriters import parseEnergyGroupStructure
-from armiopenmc import executionOptions
+from armicontrib.armiopenmc.executers import OpenMCExecuter
+from armicontrib.armiopenmc.inputWriters import parseEnergyGroupStructure
+from armicontrib.armiopenmc import executionOptions
 
-from armiopenmc.settings import (
+from armicontrib.armiopenmc.settings import (
     CONF_OPENMC_PATH,
     CONF_N_PARTICLES,
     CONF_N_BATCHES,


### PR DESCRIPTION
This works now when the package is installed
in editable mode or as a package.